### PR TITLE
fix exceptions while polling jk bms alone.

### DIFF
--- a/berrybms/Register.py
+++ b/berrybms/Register.py
@@ -35,6 +35,14 @@ class Register(object):
         self.length = length
         self.values[name] = None
 
+    @property
+    def value(self):
+        return self.values[self.name]
+
+    @value.setter
+    def value(self, val):
+        self.values[self.name] = val
+
     def getValue(self, c, reload=False):
 
         if reload == True:

--- a/berrybms/berrybms.py
+++ b/berrybms/berrybms.py
@@ -137,26 +137,27 @@ def main(daemon):
 
         # We start our Xanbus sniffer thread after polling (if enabled) the
         # InsightHome as it'll update properly populated data structures from there
-        if config['conext'].get('xanbus_sniffer', None) != None:
-            if xanbus_sniffer == None:
-                xanbus_sniffer = XanbusSniffer(config, logger)
-                xanbus_sniffer_thread = threading.Thread(target=xanbus_sniffer.sniff, daemon=False)
-                xanbus_sniffer_thread.start()
-                print("Started Xanbus sniffer thread!")
+        if config.get('conext') is not None:
+            if config['conext'].get('xanbus_sniffer', None) != None:
+                if xanbus_sniffer == None:
+                    xanbus_sniffer = XanbusSniffer(config, logger)
+                    xanbus_sniffer_thread = threading.Thread(target=xanbus_sniffer.sniff, daemon=False)
+                    xanbus_sniffer_thread.start()
+                    print("Started Xanbus sniffer thread!")
 
-        if config['conext']['insighthome'] != None:
-            conext = ConextInsightHome(config['conext']['insighthome']['host'],
-                                       config['conext']['insighthome']['port'],
-                                       config['conext']['insighthome'].get('ids', None),
-                                       config['conext'].get('serial_number_hack', None))
-            all_modbus_devices.append(conext)
-            c = conext.connect()
-            devices = conext.allDevices()
-            for device in devices:
-                device.publish(all_devices)
-                #print("%s: %s\n" % (type(device).__name__, device))
-                #device.dump()
-                print(device.formattedOutput(),'\n')
+            if config['conext']['insighthome'] != None:
+                conext = ConextInsightHome(config['conext']['insighthome']['host'],
+                                            config['conext']['insighthome']['port'],
+                                            config['conext']['insighthome'].get('ids', None),
+                                            config['conext'].get('serial_number_hack', None))
+                all_modbus_devices.append(conext)
+                c = conext.connect()
+                devices = conext.allDevices()
+                for device in devices:
+                    device.publish(all_devices)
+                    #print("%s: %s\n" % (type(device).__name__, device))
+                    #device.dump()
+                    print(device.formattedOutput(),'\n')
 
         # Publish all values in MQTT
         if paho_client != None:


### PR DESCRIPTION
- 598fe37 had removed the value property but it's still used in the codebase. So add it back.
- If conext is absent in the yaml file, proceed without it.